### PR TITLE
Implement ability to generate CDN URLs with support for Cloudinary's transforms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ dependencies {
     compile(group:'io.induct.http', name:'http-ning', version:'0.1.0')
     compile(group:'io.induct.bricks', name:'bricks-ddd', version:'0.2.0')
     compile(group:'com.google.inject.extensions', name:'guice-multibindings', version:'4.0')
-    compile(group: 'org.projectlombok', name: 'lombok', version:'1.16.2')
+    compile(group:'org.projectlombok', name: 'lombok', version:'1.16.2')
+    // Cloudinary is the image management solution used by Yle for their program images
+    compile(group:'com.cloudinary', name:'cloudinary-core', version:'1.2.1')
 }
 
 sourceSets {

--- a/src/main/java/io/induct/yle/api/YleApi.java
+++ b/src/main/java/io/induct/yle/api/YleApi.java
@@ -3,6 +3,7 @@ package io.induct.yle.api;
 import io.induct.yle.api.media.YleMediaApi;
 import io.induct.yle.api.programs.YleProgramsApi;
 import io.induct.yle.api.tracking.YleTrackingApi;
+import io.induct.yle.cdn.images.YleImagesCdn;
 
 import javax.inject.Inject;
 
@@ -14,12 +15,14 @@ public class YleApi {
     private final YleProgramsApi programsApi;
     private final YleMediaApi mediaApi;
     private final YleTrackingApi trackingApi;
+    private final YleImagesCdn imageCdn;
 
     @Inject
-    public YleApi(YleProgramsApi programsApi, YleMediaApi mediaApi, YleTrackingApi trackingApi) {
+    public YleApi(YleProgramsApi programsApi, YleMediaApi mediaApi, YleTrackingApi trackingApi, YleImagesCdn imageCdn) {
         this.programsApi = programsApi;
         this.mediaApi = mediaApi;
         this.trackingApi = trackingApi;
+        this.imageCdn = imageCdn;
     }
 
     public YleProgramsApi programs() {
@@ -32,5 +35,9 @@ public class YleApi {
 
     public YleTrackingApi tracking() {
         return trackingApi;
+    }
+
+    public YleImagesCdn imagesCdn() {
+        return imageCdn;
     }
 }

--- a/src/main/java/io/induct/yle/cdn/images/YleImagesCdn.java
+++ b/src/main/java/io/induct/yle/cdn/images/YleImagesCdn.java
@@ -1,0 +1,35 @@
+package io.induct.yle.cdn.images;
+
+import com.cloudinary.Transformation;
+import com.google.common.base.Optional;
+import io.induct.yle.api.YleId;
+import io.induct.yle.cdn.images.domain.Format;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * @since 2015-09-09
+ */
+public class YleImagesCdn {
+    private final String imageCdnBaseUrl;
+
+    @Inject
+    public YleImagesCdn(@Named("yle.images.baseUrl") String imageCdnBaseUrl) {
+        this.imageCdnBaseUrl = imageCdnBaseUrl;
+    }
+
+    public String urlFor(YleId imageId, Format format) {
+        return urlFor(imageId, format, Optional.absent());
+    }
+
+    public String urlFor(YleId imageId, Format format, Optional<Transformation> transformation) {
+        StringBuilder url = new StringBuilder();
+        url.append(imageCdnBaseUrl).append("/image/upload");
+        if (transformation.isPresent()) {
+            url.append("/").append(transformation.get().generate());
+        }
+        url.append("/").append(imageId.identity()).append(".").append(format.getApiValue());
+        return url.toString();
+    }
+}

--- a/src/main/java/io/induct/yle/cdn/images/domain/Format.java
+++ b/src/main/java/io/induct/yle/cdn/images/domain/Format.java
@@ -1,0 +1,20 @@
+package io.induct.yle.cdn.images.domain;
+
+/**
+ * @since 2015-09-09
+ */
+public enum Format {
+    JPEG("jpg"),
+    PNG("png"),
+    GIF("gif");
+
+    private final String apiValue;
+
+    Format(String apiValue) {
+        this.apiValue = apiValue;
+    }
+
+    public String getApiValue() {
+        return apiValue;
+    }
+}

--- a/src/test/java/io/induct/yle/TestDependenciesModule.java
+++ b/src/test/java/io/induct/yle/TestDependenciesModule.java
@@ -11,7 +11,8 @@ import io.induct.http.HttpClient;
  */
 public class TestDependenciesModule extends AbstractModule {
 
-    public static final String TESTING_BASE_URL = "http://yle.api";
+    public static final String TESTING_API_BASE_URL = "http://yle.api";
+    public static final String TESTING_CDN_BASE_URL = "http://yle.cdn";
     public static final String TESTING_RATE_LIMIT = "100";
     public static final String TESTING_APP_ID = "TEST_APP_ID";
     public static final String TESTING_APP_KEY = "TEST_APP_KEY";
@@ -27,7 +28,8 @@ public class TestDependenciesModule extends AbstractModule {
     protected void configure() {
         bind(HttpClient.class).toInstance(httpClient);
 
-        bind(String.class).annotatedWith(Names.named("yle.api.baseUrl")).toInstance(TESTING_BASE_URL);
+        bind(String.class).annotatedWith(Names.named("yle.images.baseUrl")).toInstance(TESTING_CDN_BASE_URL);
+        bind(String.class).annotatedWith(Names.named("yle.api.baseUrl")).toInstance(TESTING_API_BASE_URL);
         bind(String.class).annotatedWith(Names.named("yle.api.rateLimit")).toInstance(TESTING_RATE_LIMIT);
         bind(String.class).annotatedWith(Names.named("yle.api.appId")).toInstance(TESTING_APP_ID);
         bind(String.class).annotatedWith(Names.named("yle.api.appKey")).toInstance(TESTING_APP_KEY);

--- a/src/test/java/io/induct/yle/cdn/images/YleImagesCdnTest.java
+++ b/src/test/java/io/induct/yle/cdn/images/YleImagesCdnTest.java
@@ -1,0 +1,54 @@
+package io.induct.yle.cdn.images;
+
+import com.cloudinary.Transformation;
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.induct.yle.YleApiTestingBase;
+import io.induct.yle.api.YleId;
+import io.induct.yle.cdn.images.domain.Format;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @since 2015-09-09
+ */
+public class YleImagesCdnTest extends YleApiTestingBase {
+
+    private YleImagesCdn imagesCdn;
+    private Splitter atSlashes = Splitter.on('/').omitEmptyStrings();
+    private Splitter atCommas = Splitter.on(',');
+
+    @Before
+    public void setUp() throws Exception {
+        imagesCdn = injector.getInstance(YleImagesCdn.class);
+    }
+
+    @Test
+    public void shouldProduceValidCdnUrlForValidParameters() throws Exception {
+        YleId imageId = new YleId("13-1-2185369");
+        String url = imagesCdn.urlFor(imageId, Format.JPEG);
+        assertEquals(url, "http://yle.cdn/image/upload/13-1-2185369.jpg");
+    }
+
+    @Test
+    public void shouldAddTransformationsAsMidfixIfPresent() throws Exception {
+        YleId imageId = new YleId("13-1-2185369");
+        String url = imagesCdn.urlFor(imageId, Format.JPEG, Optional.of(new Transformation().width(120).height(120).crop("fit")));
+
+        // NOTE: We need to extract the params as Cloudinary's Transform class uses HashMaps making the params order
+        // independent.
+        Set<String> appliedTransformations = Sets.newHashSet(
+                atCommas.split(Lists.newArrayList(atSlashes.split(url)).get(4)));
+        assertEquals(appliedTransformations.size(), 3);
+        assertTrue(appliedTransformations.contains("c_fit"));
+        assertTrue(appliedTransformations.contains("w_120"));
+        assertTrue(appliedTransformations.contains("h_120"));
+    }
+}


### PR DESCRIPTION
Note that Cloudinary's Transform class is not the best level of quality as Java code goes but it could be worse. Only core module is included as there is no need for actual Cloudinary API calling facilities.
